### PR TITLE
Update Traefik dependency to v3.5.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
 	github.com/thomseddon/go-flags v1.4.1-0.20190507184247-a3629c504486
-	github.com/traefik/traefik/v3 v3.5.1
+	github.com/traefik/traefik/v3 v3.5.3
 	golang.org/x/oauth2 v0.31.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/thomseddon/go-flags v1.4.1-0.20190507184247-a3629c504486 h1:hk17f4niA
 github.com/thomseddon/go-flags v1.4.1-0.20190507184247-a3629c504486/go.mod h1:NK9eZpNBmSKVxvyB/MExg6jW0Bo9hQyAuCP+b8MJFow=
 github.com/traefik/paerser v0.2.2 h1:cpzW/ZrQrBh3mdwD/jnp6aXASiUFKOVr6ldP+keJTcQ=
 github.com/traefik/paerser v0.2.2/go.mod h1:7BBDd4FANoVgaTZG+yh26jI6CA2nds7D/4VTEdIsh24=
-github.com/traefik/traefik/v3 v3.5.1 h1:RY1/gQiKFtGQGPuHaR8pa85JlKwYXuNcLEAZk9fb1sY=
-github.com/traefik/traefik/v3 v3.5.1/go.mod h1:bK/+7TKiKYJyFfzpo54RpaV1Zsiav9g9QkRODp9re14=
+github.com/traefik/traefik/v3 v3.5.3 h1:LxzoigGBOEx11CRDFYDFj/GfmnJsnxAl8bDkjqmsS2o=
+github.com/traefik/traefik/v3 v3.5.3/go.mod h1:bK/+7TKiKYJyFfzpo54RpaV1Zsiav9g9QkRODp9re14=
 github.com/unrolled/render v1.7.0 h1:1yke01/tZiZpiXfUG+zqB+6fq3G4I+KDmnh0EhPq7So=
 github.com/unrolled/render v1.7.0/go.mod h1:LwQSeDhjml8NLjIO9GJO1/1qpFJxtfVIpzxXKjfVkoI=
 github.com/vulcand/predicate v1.3.0 h1:jtNe4PHbLJ649dR7Gl+MSAzUhLGtLspAkWlSjoOiXg8=


### PR DESCRIPTION
## Summary
- bump github.com/traefik/traefik/v3 to v3.5.3 to pull in the latest fixes and security updates

## Testing
- go test ./...
- /root/.local/share/mise/installs/go/1.24.3/bin/govulncheck ./...


------
https://chatgpt.com/codex/tasks/task_e_68d769c6ab308329919e4033dc677ab4